### PR TITLE
Add All-Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Software to start streaming
 
 Browser widgets for OBS to add more functionality to your stream.
 
+- [All-Chat](https://allch.at) Free, open-source chat overlay that merges Twitch with YouTube, Kick, TikTok, and Discord into a single OBS browser source. Native 7TV/BTTV/FFZ emote support.
 - [Amuse](https://6klabs.com/amuse) Show information of the current song playing in your stream.
 - [ChatIS](https://chatis.is2511.com/) jChat fork with 7TV integration.
 - [Show Emote](https://show-emote.sammwy.com) Allow your viewers to display emotes from chat using !showemote.


### PR DESCRIPTION
Adds [All-Chat](https://allch.at), an open-source (AGPL 3.0) multi-platform chat overlay that merges Twitch, YouTube, Kick, TikTok, and Discord into a single OBS browser source with native 7TV/BTTV/FFZ emote support.

Source: https://github.com/caesarakalaeii/all-chat