### PR TITLE
Add Wheel of Item under Widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Browser widgets for OBS to add more functionality to your stream.
 - [StreamElements](https://streamelements.com/) Varied widget service (Chatbox, donation alert, goals)
 - [Streamlabs](https://streamlabs.com/es-es/cloudbot) Varied widget service (Chatbox, donation alert, goals)
 - [Vizz.fm](https://vizz.fm) Browser-based music visualizer with customizable scenes and presets, usable as an OBS browser source.
+- [Wheel of Item](https://wheelofitem.com) Free spin wheel & gachapon prize machine as an OBS browser source; chat triggers it with !spin, or auto-spin on Streamlabs/StreamElements/Ko-fi donations.
 
 ### Analytics
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Browser widgets for OBS to add more functionality to your stream.
 - [StreamElements](https://streamelements.com/) Varied widget service (Chatbox, donation alert, goals)
 - [Streamlabs](https://streamlabs.com/es-es/cloudbot) Varied widget service (Chatbox, donation alert, goals)
 - [Vizz.fm](https://vizz.fm) Browser-based music visualizer with customizable scenes and presets, usable as an OBS browser source.
-- [Wheel of Item](https://wheelofitem.com) Free spin wheel & gachapon prize machine as an OBS browser source; chat triggers it with !spin, or auto-spin on Streamlabs/StreamElements/Ko-fi donations.
 
 ### Analytics
 
@@ -83,6 +82,7 @@ Various utilities for your stream that do not fall into a specific category
 - [chat.vote](https://chat.vote/) Create polls and raffles for the chat, let your viewers vote or make suggestions.
 - [ClipSpeedAI](https://clipspeed.ai) AI clip extractor — finds highlights in long-form VODs and renders short verticals for TikTok / Shorts / Reels.
 - [StreamWorlds](https://streamworlds.io/) A free Twitch extension that lets you create immersive 3D virtual spaces for your community. Boost engagement and fun.
+- [Wheel of Item](https://wheelofitem.com) Free spin wheel & gachapon prize machine for streamers — viewers trigger it from chat with !spin, or it auto-spins on Streamlabs/StreamElements/Ko-fi donations.
 
 ### OBS Plugins
 


### PR DESCRIPTION
Adds [Wheel of Item](https://wheelofitem.com) to the **Widgets** section.

It's a free browser-source overlay for OBS — a spin wheel and gachapon prize machine that viewers trigger from Twitch chat with `!spin`, or that auto-spins on Streamlabs / StreamElements / Ko-fi donations. Sits alongside the other OBS browser widgets in the list; kept alphabetical (after Vizz.fm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
