### PR TITLE
Add ClipMe to Misc Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Various utilities for your stream that do not fall into a specific category
 
 - [BetterStreams](https://betterstreams.tv) Stream automation that connects channel point redeems, subs, raids, and 16 other triggers to OBS actions, TTS, and giveaways. Includes reward management with auto-toggling by game category and redemption analytics.
 - [chat.vote](https://chat.vote/) Create polls and raffles for the chat, let your viewers vote or make suggestions.
+- [ClipMe](https://clipme.com) AI clip maker for live streams — turns Twitch, Kick and YouTube streams and VODs into captioned vertical shorts, ranking moments by chat activity.
 - [ClipSpeedAI](https://clipspeed.ai) AI clip extractor — finds highlights in long-form VODs and renders short verticals for TikTok / Shorts / Reels.
 - [StreamWorlds](https://streamworlds.io/) A free Twitch extension that lets you create immersive 3D virtual spaces for your community. Boost engagement and fun.
 


### PR DESCRIPTION
Adds [ClipMe](https://clipme.com) — an AI clip maker for live streams. It ingests Twitch, Kick and YouTube streams and VODs, ranks moments using signals including chat activity, and renders captioned vertical shorts.

Placed alphabetically in Misc Tools, matching the existing entry format (same category as ClipSpeedAI).

Disclosure: I work on ClipMe.