### PR TITLE
Add Emote Resizer to Emote Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Tools and utilities about emotes.
 - [Twitch Emotes](https://twitchemotes.com/) It allows you to view the emotes of any channel.
 - [Twitch Emote Resizer](https://tma02.github.io/twitch-emote-resizer/) Automatically resize emotes to required sizes.
 - [EmoteResizer](https://emoteresizer.net) Free toolkit for streamers: resize emotes, sub/bit badges and stickers to exact Twitch, Discord, Kick, Slack, 7TV and YouTube sizes (animated GIFs supported), plus Twitch Bits and subscription revenue calculators. Browser-based, no signup.
+- [Emote Resizer](https://emoteresize.com) Turns one image into every Twitch, Discord, 7TV/BTTV/FFZ and Slack emote, badge and sticker size. Supports PNG and animated GIF, batch input and auto-compression; runs fully client-side with no upload or signup.
 
 ### Emotes
 


### PR DESCRIPTION
Adds **Emote Resizer** (https://emoteresize.com) to the *Emote Tools* section.

It takes a single image and exports every size the platforms ask for — Twitch emotes (28/56/112) and sub badges (18/36/72), Discord emoji and stickers, 7TV / BetterTTV / FrankerFaceZ, Slack, plus custom sizes. Handles animated GIFs with frames preserved, supports batch input, and auto-compresses each output to stay under the per-platform byte limits.

All processing runs client-side in the browser, so nothing is uploaded and no account is needed. Free, no signup.
