### PR TITLE
Add Xenon to Misc Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Various utilities for your stream that do not fall into a specific category
 - [NoSub](https://nosubapp.com) Watch Twitch and Kick VODs including sub-only replays, with the original chat replayed in sync. Free, no account, nothing to install.
 - [StreamWorlds](https://streamworlds.io/) A free Twitch extension that lets you create immersive 3D virtual spaces for your community. Boost engagement and fun.
 - [Wheel of Item](https://wheelofitem.com) Free spin wheel & gachapon prize machine for streamers — viewers trigger it from chat with !spin, or it auto-spins on Streamlabs/StreamElements/Ko-fi donations.
+- [Xenon](https://xenon-app.com) Dashboard for a spare screen, tablet or phone that controls OBS, Streamer.bot, Twitch and per-app audio, with a Stream Deck style touch grid and RGB lighting. Runs entirely on your machine, no account.
 
 ### OBS Plugins
 


### PR DESCRIPTION
Adds Xenon to Misc Tools.

Xenon is a dashboard you run on your own PC and open from a spare monitor, a tablet or a phone. For streaming it covers OBS and Streamer.bot control, Twitch chat and events, per-app audio levels and device switching, a Stream Deck style touch grid with macros, and RGB lighting across iCUE, Hue, WLED and Nanoleaf. Windows, with macOS and Linux in beta. No account, no telemetry, nothing leaves the machine.

I am the author of the project. Placed alphabetically at the end of Misc Tools, following the existing entry format.
