### PR TITLE
Add CodingFreaks Chat Overlay to Widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Browser widgets for OBS to add more functionality to your stream.
 - [All-Chat](https://allch.at) Free, open-source chat overlay that merges Twitch with YouTube, Kick, TikTok, and Discord into a single OBS browser source. Native 7TV/BTTV/FFZ emote support.
 - [Amuse](https://6klabs.com/amuse) Show information of the current song playing in your stream.
 - [ChatIS](https://chatis.is2511.com/) jChat fork with 7TV integration.
+- [CodingFreaks Chat Overlay](https://twitch-overlays.coding-freaks.com/en/overlays/chat-overlay) Free display-only chat overlay with native 7TV, BTTV and FFZ emotes and six themes. Runs from a single HTML file, so it needs no bot account and no OAuth token.
 - [Show Emote](https://show-emote.sammwy.com) Allow your viewers to display emotes from chat using !showemote.
 - [showmy.chat](https://showmy.chat/) Instant, themed Twitch chat overlays.
 - [SoundAlerts](https://soundalerts.com/) Allow your viewers to play sounds in your stream with bits.


### PR DESCRIPTION
Adds CodingFreaks Chat Overlay to the Widgets section, sorted alphabetically after ChatIS.

Disclosure: this is my own project.

It is a display-only chat overlay: it reads chat and never writes to it, so there is no bot account and no OAuth token involved. Native 7TV, BTTV and FFZ emotes, six themes, configurable message lifetime and stack direction. It ships as a single HTML file for a Browser Source and is free.

It differs from the entries already listed: All-Chat merges several platforms into one feed, ChatIS is a jChat fork, and StreamElements/Streamlabs are hosted widget services. This one is a local file with no account at all.