### PR TITLE
Add TipStreams to Widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Browser widgets for OBS to add more functionality to your stream.
 - [StreamElements](https://streamelements.com/) Varied widget service (Chatbox, donation alert, goals)
 - [Streamlabs](https://streamlabs.com/es-es/cloudbot) Varied widget service (Chatbox, donation alert, goals)
 - [StreamTranslate](https://streamtranslate.live) Adds real-time translated subtitles to your stream through an browser sourse.
+- [TipStreams](https://tipstreams.com/widget/) Free embeddable tip-QR overlay (OBS browser source): one QR for crypto, PayPal, Cash App, Venmo, and Ko-fi. No account, no fees.
 - [Vizz.fm](https://vizz.fm) Browser-based music visualizer with customizable scenes and presets, usable as an OBS browser source.
 - [Kloot](https://kloot.gg) Browser-based control deck for streamers: fire giveaways, live polls, lower thirds and hype effects from one OBS browser source, controlled from your phone.
 


### PR DESCRIPTION
Adds **TipStreams** to the Widgets section — a free, embeddable tip-QR overlay you can drop in as an OBS browser source. One QR routes viewers to crypto (BIP-21), PayPal, Cash App, Venmo, or Ko-fi. No account, no fees, nothing leaves the browser (it points at the streamer's own wallets/links).

- Demo/embed: https://tipstreams.com/widget/
- Source (MIT): https://github.com/zengineco/tip-widget

Placed alphabetically in Widgets, matching the existing entry format.