### PR TITLE
Add PickerSpin to Misc Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Various utilities for your stream that do not fall into a specific category
 - [ClipMe](https://clipme.com) AI clip maker for live streams — turns Twitch, Kick and YouTube streams and VODs into captioned vertical shorts, ranking moments by chat activity.
 - [ClipSpeedAI](https://clipspeed.ai) AI clip extractor — finds highlights in long-form VODs and renders short verticals for TikTok / Shorts / Reels.
 - [NoSub](https://nosubapp.com) Watch Twitch and Kick VODs including sub-only replays, with the original chat replayed in sync. Free, no account, nothing to install.
+- [PickerSpin](https://pickerspin.co) Free wheel spinner, dice roller and bingo caller for drawing giveaway winners — provably fair (Web Crypto API, publicly verifiable), no donation gate, no account.
 - [StreamWorlds](https://streamworlds.io/) A free Twitch extension that lets you create immersive 3D virtual spaces for your community. Boost engagement and fun.
 - [Wheel of Item](https://wheelofitem.com) Free spin wheel & gachapon prize machine for streamers — viewers trigger it from chat with !spin, or it auto-spins on Streamlabs/StreamElements/Ko-fi donations.
 


### PR DESCRIPTION
Adds PickerSpin under Misc Tools — a free, no-account wheel spinner for giveaway draws, with a public fairness-verification page so viewers can check a draw wasn't rigged. Also includes a dice roller and bingo caller.